### PR TITLE
TAO-5741 - resolve negative seconds issue.

### DIFF
--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -230,7 +230,6 @@ class DateTime extends \DateTime
         $d1Ts = $d1->getTimestampWithMicroseconds();
         $d2Ts = $d2->getTimestampWithMicroseconds();
         $negative = $d1Ts > $d2Ts;
-        $invert = $absolute ? false : $negative;
 
         $d1s = intval($d1Ts);
         $d2s = intval($d2Ts);
@@ -260,7 +259,7 @@ class DateTime extends \DateTime
 
 
         $interval->u = round($u, 6) * 1e6;
-        $interval->invert = $invert;
+        $interval->invert = $absolute ? false : $negative;;
 
         return $interval;
     }

--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -221,11 +221,19 @@ class DateTime extends \DateTime
      * @param \DateTime $datetime
      * @param bool|false $absolute
      * @return DateInterval
+     * @throws \InvalidArgumentException In case of $datetime is not a DateTime nor a oat\dtms\DateTime object.
      */
     public function diff($datetime, $absolute = false)
     {
         $d1 = clone $this;
-        $d2 = $datetime instanceof \DateTime ? new static($datetime->format(DateTime::ISO8601)) : clone $datetime;
+
+        if ($datetime instanceof \DateTime) {
+            $d2 = new static($datetime->format(DateTime::ISO8601));
+        } elseif ($datetime instanceof DateTime) {
+            $d2 = clone $datetime;
+        } else {
+            throw new \InvalidArgumentException('First Argument must be an instance of DateTime or oat\dtms\DateTime');
+        }
 
         $d1Ts = $d1->getTimestampWithMicroseconds();
         $d2Ts = $d2->getTimestampWithMicroseconds();

--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -227,30 +227,42 @@ class DateTime extends \DateTime
         $d1 = clone $this;
         $d2 = $datetime instanceof \DateTime ? new static($datetime->format(DateTime::ISO8601)) : clone $datetime;
 
+        $d1Ts = $d1->getTimestampWithMicroseconds();
+        $d2Ts = $d2->getTimestampWithMicroseconds();
+        $negative = $d1Ts > $d2Ts;
+        $invert = $absolute ? false : $negative;
+
+        $d1s = intval($d1Ts);
+        $d2s = intval($d2Ts);
+        $d1u = round($d1Ts - $d1s, 6);
+        $d2u = round($d2Ts - $d2s, 6);
+
+        if (!$negative) {
+            $comparison = $d2u < $d1u;
+            $u = $d2u - $d1u;
+        } else {
+            $comparison = $d2u > $d1u;
+            $u = $d1u - $d2u;
+        }
+
+        if ($u < 0) {
+            $u += 1;
+        }
+
+        if ($comparison) {
+            $sign = $negative ? '+' : '-';
+            $d2->modify("${sign}1 second");
+        }
+
         $interval = new DateInterval('PT0.000000S');
-        foreach (get_object_vars(parent::diff($datetime)) as $property => $value) {
+        foreach (get_object_vars(parent::diff($d2)) as $property => $value) {
             $interval->{$property} = $value;
         }
-        $interval->s = 0;
 
-        $negative = $d1->getTimestampWithMicroseconds() > $d2->getTimestampWithMicroseconds();
-        $diff = abs($d1->getTimestampWithMicroseconds() - $d2->getTimestampWithMicroseconds());
+        $u = round($u, 6) * 1e6;
 
-        $seconds = intval($diff);
-        $microseconds = round($diff - $seconds, 6) * 1e6;
-
-        $now = new \DateTime($d2);
-        $start = $now->getTimestamp();
-
-        $operation = $negative ? 'sub' : 'add';
-        $now->$operation($interval);
-
-        $end = $now->getTimestamp();
-        $antiseconds = abs($end - $start);
-
-        $interval->s = $seconds - $antiseconds;
-        $interval->u = $microseconds;
-        $interval->invert = $absolute ? false : $negative;
+        $interval->u = $u;
+        $interval->invert = $invert;
 
         return $interval;
     }

--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -250,8 +250,7 @@ class DateTime extends \DateTime
         }
 
         if ($comparison) {
-            $sign = $negative ? '+' : '-';
-            $d2->modify("${sign}1 second");
+            $d2->modify(($negative ? '+' : '-') . '1 second');
         }
 
         $interval = new DateInterval('PT0.000000S');
@@ -259,9 +258,8 @@ class DateTime extends \DateTime
             $interval->{$property} = $value;
         }
 
-        $u = round($u, 6) * 1e6;
 
-        $interval->u = $u;
+        $interval->u = round($u, 6) * 1e6;
         $interval->invert = $invert;
 
         return $interval;

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -27,7 +27,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::getMicroseconds
+     * @covers \oat\dtms\DateTime::getMicroseconds
      */
     public function testSetMicroseconds()
     {
@@ -48,7 +48,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::getMicroseconds
+     * @covers \oat\dtms\DateTime::getMicroseconds
      */
     public function testGetMicroseconds()
     {
@@ -63,7 +63,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::createFromFormat
+     * @covers \oat\dtms\DateTime::createFromFormat
      */
     public function testCreateFromFormat()
     {
@@ -74,7 +74,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::__construct
+     * @covers \oat\dtms\DateTime::__construct
      */
     public function testConstruct()
     {
@@ -87,7 +87,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::getTimestampWithMicroseconds
+     * @covers \oat\dtms\DateTime::getTimestampWithMicroseconds
      */
     public function testGetTimestampWithMicroseconds()
     {
@@ -96,7 +96,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::addMicroseconds
+     * @covers \oat\dtms\DateTime::addMicroseconds
      */
     public function testAddMicroseconds()
     {
@@ -128,7 +128,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::subMicroseconds
+     * @covers \oat\dtms\DateTime::subMicroseconds
      */
     public function testSubMicroseconds()
     {
@@ -160,7 +160,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::add
+     * @covers \oat\dtms\DateTime::add
      */
     public function testAdd()
     {
@@ -199,7 +199,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::sub
+     * @covers \oat\dtms\DateTime::sub
      */
     public function testSub()
     {
@@ -238,7 +238,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::modify
+     * @covers \oat\dtms\DateTime::modify
      */
     public function testModify()
     {
@@ -316,10 +316,11 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::diff
+     * @covers \oat\dtms\DateTime::diff
      */
     public function testDiff()
     {
+        // Using oat\dtms\DateTime objects for both date 1 & date 2.
         $dt1 = new DateTime('2005-10-10 23:57:01.100000');
         $dt2 = new DateTime('2005-10-10 23:59:01.050000');
         $this->assertEquals('+PT1M59.950000S', $dt1->diff($dt2)->format('%RPT%iM%sS'));
@@ -355,8 +356,8 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
 
         $dt1 = new DateTime('2015-08-08 10:10:10.123456');
         $dt2 = new DateTime('2015-08-18 10:10:05.654321');
-        $this->assertEquals('+P9DT55.530865S', $dt1->diff($dt2)->format('%RP%dDT%sS'));
-        $this->assertEquals('-P9DT55.530865S', $dt2->diff($dt1)->format('%RP%dDT%sS'));
+        $this->assertEquals('+P9DT23H59M55.530865S', $dt1->diff($dt2)->format('%RP%dDT%hH%iM%sS'));
+        $this->assertEquals('-P9DT23H59M55.530865S', $dt2->diff($dt1)->format('%RP%dDT%hH%iM%sS'));
 
         $dt1 = new DateTime('2015-08-08 10:10:10.123456');
         $dt2 = new DateTime('2015-12-12 10:10:10.123456');
@@ -365,12 +366,56 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
 
         $dt1 = new DateTime('2015-08-10 10:10:10.101010');
         $dt2 = new DateTime('2018-08-14 16:18:10.101010');
-        $this->assertEquals('+P3Y0M4DT6H8I0S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iI%sS'));
-        $this->assertEquals('-P3Y0M4DT6H8I0S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iI%sS'));
+        $this->assertEquals('+P3Y0M4DT6H8M0S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P3Y0M4DT6H8M0S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        // Using oat\dtms\DateTime objects as date 1 & \DateTime as date 2.
+        $dt1 = new DateTime('2005-10-10 23:57:01.100000');
+        $dt2 = new \DateTime('2005-10-10 23:59:01');
+        $this->assertEquals('+PT1M59.900000S', $dt1->diff($dt2)->format('%RPT%iM%sS'));
+
+        $dt1 = new DateTime('2005-10-10 23:59:01.555554');
+        $dt2 = new \DateTime('2005-12-30 23:59:01');
+        $this->assertEquals('+P2M19DT59.444446S', $dt1->diff($dt2)->format('%RP%mM%dDT%sS'));
+
+        $dt1 = new DateTime('2015-08-08 10:10:10.123456');
+        $dt2 = new \DateTime('2015-08-08 10:10:05');
+        $this->assertEquals('-PT5.123456S', $dt1->diff($dt2)->format('%RPT%sS'));
+        $this->assertEquals('+PT5S', $dt2->diff($dt1)->format('%RPT%sS'));
+
+        $dt1 = new DateTime('2015-08-08 10:10:10.123456');
+        $dt2 = new \DateTime('2015-08-08 10:10:15');
+        $this->assertEquals('+PT4.876544S', $dt1->diff($dt2)->format('%RPT%sS'));
+        $this->assertEquals('-PT5S', $dt2->diff($dt1)->format('%RPT%sS'));
+
+        $dt1 = new DateTime('2015-08-08 10:10:10.123456');
+        $dt2 = new \DateTime('2015-08-08 10:10:10');
+        $this->assertEquals('-PT0.123456S', $dt1->diff($dt2)->format('%RPT%sS'));
+        $this->assertEquals('+PT0S', $dt2->diff($dt1)->format('%RPT%sS'));
+
+        $dt1 = new DateTime('2015-08-08 10:10:10.123456');
+        $dt2 = new \DateTime('2015-08-08 10:10:11');
+        $this->assertEquals('+PT0.876544S', $dt1->diff($dt2, true)->format('%RPT%sS'));
+        $this->assertEquals('+PT1S', $dt2->diff($dt1, true)->format('%RPT%sS'));
+
+        $dt1 = new DateTime('2015-08-08 10:10:10.123456');
+        $dt2 = new \DateTime('2015-08-18 10:10:05');
+        $this->assertEquals('+P9DT23H59M54.876544S', $dt1->diff($dt2)->format('%RP%dDT%hH%iM%sS'));
+        $this->assertEquals('-P9DT23H59M55S', $dt2->diff($dt1)->format('%RP%dDT%hH%iM%sS'));
+
+        $dt1 = new DateTime('2015-08-08 10:10:10.123456');
+        $dt2 = new \DateTime('2015-12-12 10:10:10');
+        $this->assertEquals('+P4M3DT23H59M59.876544S', $dt1->diff($dt2)->format('%RP%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P4M4DT0S', $dt2->diff($dt1)->format('%RP%mM%dDT%sS'));
+
+        $dt1 = new DateTime('2015-08-10 10:10:10.101010');
+        $dt2 = new \DateTime('2018-08-14 16:18:10');
+        $this->assertEquals('+P3Y0M4DT6H7M59.898990S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P3Y0M4DT6H8M0S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
     }
 
     /**
-     * @covers oat\dtms\DateTime::__toString
+     * @covers \oat\dtms\DateTime::__toString
      */
     public function testToString()
     {
@@ -385,7 +430,7 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers oat\dtms\DateTime::format
+     * @covers \oat\dtms\DateTime::format
      */
     public function testFormat()
     {

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -324,6 +324,10 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $dt2 = new DateTime('2005-10-10 23:59:01.050000');
         $this->assertEquals('+PT1M59.950000S', $dt1->diff($dt2)->format('%RPT%sS'));
         
+        $dt1 = new DateTime('2005-10-10 23:59:01.555554');
+        $dt2 = new DateTime('2005-12-30 23:59:01.555555');
+        $this->assertEquals('+P2M20DT0.000001', $dt1->diff($dt2)->format('%RPT%sS'));
+        
         $dt1 = new DateTime('2015-08-08 10:10:10.123456');
         $dt2 = new DateTime('2015-08-08 10:10:05.654321');
         $this->assertEquals('-PT4.469135S', $dt1->diff($dt2)->format('%RPT%sS'));

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -456,6 +456,32 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $dt2 = new \DateTime('1985-11-27 10:00:10');
         $this->assertEquals('+P0Y0M0DT0H0M4.010000S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
         $this->assertEquals('-P0Y0M0DT0H0M5S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        // Using DateTime objects as date 1 AND oat\dtms\DateTime as date 2.
+        $dt1 = new \DateTime('2005-10-10 23:57:01');
+        $dt2 = new DateTime('2005-10-10 23:59:01.050000');
+        $this->assertEquals('+PT2M0S', $dt1->diff($dt2)->format('%RPT%iM%sS'));
+        $this->assertEquals('-PT2M0.050000S', $dt2->diff($dt1)->format('%RPT%iM%sS'));
+
+        $dt1 = new \DateTime('2005-10-10 23:59:01');
+        $dt2 = new DateTime('2005-12-30 23:59:01.555555');
+        $this->assertEquals('+P2M20DT0S', $dt1->diff($dt2)->format('%RP%mM%dDT%sS'));
+        $this->assertEquals('-P2M20DT0.555555S', $dt2->diff($dt1)->format('%RP%mM%dDT%sS'));
+
+        $dt1 = new \DateTime('2015-08-08 10:10:10');
+        $dt2 = new DateTime('2015-08-08 10:10:05.654321');
+        $this->assertEquals('-PT5S', $dt1->diff($dt2)->format('%RPT%sS'));
+        $this->assertEquals('+PT4.345679S', $dt2->diff($dt1)->format('%RPT%sS'));
+
+        $dt1 = new \DateTime('2015-08-08 10:10:10');
+        $dt2 = new DateTime('2015-08-08 10:10:10.123455');
+        $this->assertEquals('+PT0S', $dt1->diff($dt2)->format('%RPT%sS'));
+        $this->assertEquals('-PT0.123455S', $dt2->diff($dt1)->format('%RPT%sS'));
+
+        $dt1 = new \DateTime('2015-08-08 10:10:10');
+        $dt2 = new DateTime('2015-08-08 10:10:15.654321');
+        $this->assertEquals('+PT5S', $dt1->diff($dt2)->format('%RPT%sS'));
+        $this->assertEquals('-PT5.654321S', $dt2->diff($dt1)->format('%RPT%sS'));
     }
 
     /**

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -482,6 +482,51 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $dt2 = new DateTime('2015-08-08 10:10:15.654321');
         $this->assertEquals('+PT5S', $dt1->diff($dt2)->format('%RPT%sS'));
         $this->assertEquals('-PT5.654321S', $dt2->diff($dt1)->format('%RPT%sS'));
+
+        $dt1 = new \DateTime('2015-08-08 10:10:10');
+        $dt2 = new DateTime('2015-08-08 10:10:10.123456');
+        $this->assertEquals('+PT0S', $dt1->diff($dt2)->format('%RPT%sS'));
+        $this->assertEquals('-PT0.123456S', $dt2->diff($dt1)->format('%RPT%sS'));
+
+        $dt1 = new \DateTime('2015-08-08 10:10:10');
+        $dt2 = new DateTime('2015-08-08 10:10:11.654321');
+        $this->assertEquals('+PT1S', $dt1->diff($dt2, true)->format('%RPT%sS'));
+        $this->assertEquals('+PT1.654321S', $dt2->diff($dt1, true)->format('%RPT%sS'));
+
+        $dt1 = new \DateTime('2015-08-08 10:10:10');
+        $dt2 = new DateTime('2015-08-18 10:10:05.654321');
+        $this->assertEquals('+P9DT23H59M55S', $dt1->diff($dt2)->format('%RP%dDT%hH%iM%sS'));
+        $this->assertEquals('-P9DT23H59M55.654321S', $dt2->diff($dt1)->format('%RP%dDT%hH%iM%sS'));
+
+        $dt1 = new \DateTime('2015-08-08 10:10:10');
+        $dt2 = new DateTime('2015-12-12 10:10:10.123456');
+        $this->assertEquals('+P4M4DT0S', $dt1->diff($dt2)->format('%RP%mM%dDT%sS'));
+        $this->assertEquals('-P4M4DT0.123456S', $dt2->diff($dt1)->format('%RP%mM%dDT%sS'));
+
+        $dt1 = new \DateTime('2015-08-10 10:10:10');
+        $dt2 = new DateTime('2018-08-14 16:18:10.101010');
+        $this->assertEquals('+P3Y0M4DT6H8M0S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P3Y0M4DT6H8M0.101010S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new \DateTime('1985-11-27 10:00:00');
+        $dt2 = new DateTime('1985-11-27 10:00:00.340000');
+        $this->assertEquals('+P0Y0M0DT0H0M0S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M0.340000S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new \DateTime('1985-11-27 10:00:05');
+        $dt2 = new DateTime('1985-11-27 10:00:10.100000');
+        $this->assertEquals('+P0Y0M0DT0H0M5S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M5.100000S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new \DateTime('1985-11-27 10:00:05');
+        $dt2 = new DateTime('1985-11-27 10:00:10.440000');
+        $this->assertEquals('+P0Y0M0DT0H0M5S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M5.440000S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new \DateTime('1985-11-27 10:00:05.990000');
+        $dt2 = new DateTime('1985-11-27 10:00:10.999999');
+        $this->assertEquals('+P0Y0M0DT0H0M5S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M5.009999S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
     }
 
     /**

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -320,6 +320,10 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
      */
     public function testDiff()
     {
+        $dt1 = new DateTime('2005-10-10 23:57:01.100000');
+        $dt2 = new DateTime('2005-10-10 23:59:01.050000');
+        $this->assertEquals('+PT1M59.950000S', $dt1->diff($dt2)->format('%RPT%sS'));
+        
         $dt1 = new DateTime('2015-08-08 10:10:10.123456');
         $dt2 = new DateTime('2015-08-08 10:10:05.654321');
         $this->assertEquals('-PT4.469135S', $dt1->diff($dt2)->format('%RPT%sS'));

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -324,10 +324,12 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $dt1 = new DateTime('2005-10-10 23:57:01.100000');
         $dt2 = new DateTime('2005-10-10 23:59:01.050000');
         $this->assertEquals('+PT1M59.950000S', $dt1->diff($dt2)->format('%RPT%iM%sS'));
+        $this->assertEquals('-PT1M59.950000S', $dt2->diff($dt1)->format('%RPT%iM%sS'));
         
         $dt1 = new DateTime('2005-10-10 23:59:01.555554');
         $dt2 = new DateTime('2005-12-30 23:59:01.555555');
         $this->assertEquals('+P2M20DT0.000001S', $dt1->diff($dt2)->format('%RP%mM%dDT%sS'));
+        $this->assertEquals('-P2M20DT0.000001S', $dt2->diff($dt1)->format('%RP%mM%dDT%sS'));
         
         $dt1 = new DateTime('2015-08-08 10:10:10.123456');
         $dt2 = new DateTime('2015-08-08 10:10:05.654321');
@@ -373,10 +375,12 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $dt1 = new DateTime('2005-10-10 23:57:01.100000');
         $dt2 = new \DateTime('2005-10-10 23:59:01');
         $this->assertEquals('+PT1M59.900000S', $dt1->diff($dt2)->format('%RPT%iM%sS'));
+        $this->assertEquals('-PT2M0S', $dt2->diff($dt1)->format('%RPT%iM%sS'));
 
         $dt1 = new DateTime('2005-10-10 23:59:01.555554');
         $dt2 = new \DateTime('2005-12-30 23:59:01');
         $this->assertEquals('+P2M19DT59.444446S', $dt1->diff($dt2)->format('%RP%mM%dDT%sS'));
+        $this->assertEquals('-P2M20DT0S', $dt2->diff($dt1)->format('%RP%mM%dDT%sS'));
 
         $dt1 = new DateTime('2015-08-08 10:10:10.123456');
         $dt2 = new \DateTime('2015-08-08 10:10:05');

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -529,6 +529,12 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('-P0Y0M0DT0H0M5.009999S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
     }
 
+    public function testDiffInvalidArgument() {
+        $this->setExpectedException('\InvalidArgumentException');
+        $dt1 = new DateTime('1985-11-27 10:00:05.990000');
+        $diff = $dt1->diff(new \stdClass());
+    }
+
     /**
      * @covers \oat\dtms\DateTime::__toString
      */

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -371,7 +371,27 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('+P3Y0M4DT6H8M0S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
         $this->assertEquals('-P3Y0M4DT6H8M0S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
 
-        // Using oat\dtms\DateTime objects as date 1 & \DateTime as date 2.
+        $dt1 = new DateTime('1985-11-27 10:00:00.340000');
+        $dt2 = new DateTime('1985-11-27 10:00:00.340000');
+        $this->assertEquals('+P0Y0M0DT0H0M0S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('+P0Y0M0DT0H0M0S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new DateTime('1985-11-27 10:00:05.990000');
+        $dt2 = new DateTime('1985-11-27 10:00:10.100000');
+        $this->assertEquals('+P0Y0M0DT0H0M4.110000S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M4.110000S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new DateTime('1985-11-27 10:00:05.450000');
+        $dt2 = new DateTime('1985-11-27 10:00:10.440000');
+        $this->assertEquals('+P0Y0M0DT0H0M4.990000S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M4.990000S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new DateTime('1985-11-27 10:00:05.990000');
+        $dt2 = new DateTime('1985-11-27 10:00:10.999999');
+        $this->assertEquals('+P0Y0M0DT0H0M5.009999S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M5.009999S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        // Using oat\dtms\DateTime objects as date 1 AND \DateTime as date 2.
         $dt1 = new DateTime('2005-10-10 23:57:01.100000');
         $dt2 = new \DateTime('2005-10-10 23:59:01');
         $this->assertEquals('+PT1M59.900000S', $dt1->diff($dt2)->format('%RPT%iM%sS'));
@@ -416,6 +436,26 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
         $dt2 = new \DateTime('2018-08-14 16:18:10');
         $this->assertEquals('+P3Y0M4DT6H7M59.898990S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
         $this->assertEquals('-P3Y0M4DT6H8M0S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new DateTime('1985-11-27 10:00:00.340000');
+        $dt2 = new \DateTime('1985-11-27 10:00:00');
+        $this->assertEquals('-P0Y0M0DT0H0M0.340000S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('+P0Y0M0DT0H0M0S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new DateTime('1985-11-27 10:00:05.990000');
+        $dt2 = new \DateTime('1985-11-27 10:00:10');
+        $this->assertEquals('+P0Y0M0DT0H0M4.010000S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M5S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new DateTime('1985-11-27 10:00:05.450000');
+        $dt2 = new \DateTime('1985-11-27 10:00:10');
+        $this->assertEquals('+P0Y0M0DT0H0M4.550000S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M5S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+
+        $dt1 = new DateTime('1985-11-27 10:00:05.990000');
+        $dt2 = new \DateTime('1985-11-27 10:00:10');
+        $this->assertEquals('+P0Y0M0DT0H0M4.010000S', $dt1->diff($dt2)->format('%RP%yY%mM%dDT%hH%iM%sS'));
+        $this->assertEquals('-P0Y0M0DT0H0M5S', $dt2->diff($dt1)->format('%RP%yY%mM%dDT%hH%iM%sS'));
     }
 
     /**

--- a/test/DateTimeTest.php
+++ b/test/DateTimeTest.php
@@ -322,11 +322,11 @@ class DateTimeTest extends \PHPUnit_Framework_TestCase
     {
         $dt1 = new DateTime('2005-10-10 23:57:01.100000');
         $dt2 = new DateTime('2005-10-10 23:59:01.050000');
-        $this->assertEquals('+PT1M59.950000S', $dt1->diff($dt2)->format('%RPT%sS'));
+        $this->assertEquals('+PT1M59.950000S', $dt1->diff($dt2)->format('%RPT%iM%sS'));
         
         $dt1 = new DateTime('2005-10-10 23:59:01.555554');
         $dt2 = new DateTime('2005-12-30 23:59:01.555555');
-        $this->assertEquals('+P2M20DT0.000001', $dt1->diff($dt2)->format('%RPT%sS'));
+        $this->assertEquals('+P2M20DT0.000001S', $dt1->diff($dt2)->format('%RP%mM%dDT%sS'));
         
         $dt1 = new DateTime('2015-08-08 10:10:10.123456');
         $dt2 = new DateTime('2015-08-08 10:10:05.654321');


### PR DESCRIPTION
**THIS WILL HAVE TO RELEASED AS A MAJOR VERSION TO AVOID ANY RISKS FOR CURRENT DEPLOYMENTS** -> QTI-SDK legacy requires version ~0.5

See JIRA ticket https://oat-sa.atlassian.net/browse/TAO-5741

This PR highlights an issue where `DateTime::diff()` returns a `DateInterval` object with its `s` property having a negative integer. This produces issues in QTI-SDK's `QtiDuration::__toString()` method, producing invalid ISO 8601 periods.

We added 2 Test Cases where it fails in the current `develop` branch.

**TestCase 1**

```php
$dt1 = new DateTime('2005-10-10 23:57:01.100000');
$dt2 = new DateTime('2005-10-10 23:59:01.050000');
$this->assertEquals('+PT1M59.950000S', $dt1->diff($dt2)->format('%RPT%iM%sS'));
```
Expected: `PT1M59.950000S`
Actual: `+PT2M-1.950000S`

Returned `oat\dtms\DateInterval`

```
object(oat\dtms\DateInterval)#29 (16) {
  ["u"]=>
  float(950000)
  ["weekday"]=>
  int(0)
  ["weekday_behavior"]=>
  int(0)
  ["first_last_day_of"]=>
  int(0)
  ["days"]=>
  bool(false)
  ["special_type"]=>
  int(0)
  ["special_amount"]=>
  int(0)
  ["have_weekday_relative"]=>
  int(0)
  ["have_special_relative"]=>
  int(0)
  ["y"]=>
  int(0)
  ["m"]=>
  int(0)
  ["d"]=>
  int(0)
  ["h"]=>
  int(0)
  ["i"]=>
  int(2)
  ["s"]=>
  int(-1)
  ["invert"]=>
  int(0)
}
```

**TestCase 2**

```php
$dt1 = new DateTime('2005-10-10 23:59:01.555554');
$dt2 = new DateTime('2005-12-30 23:59:01.555555');
$this->assertEquals('+P2M20DT0.000001S', $dt1->diff($dt2)->format('%RP%mM%dDT%sS'));
```

Expected: `+P2M20DT0.000001S`
Actual: `+P2M20DT-86400.000001S`

Returned `oat\dtms\DateInterval`

```
object(oat\dtms\DateInterval)#29 (16) {
  ["u"]=>
  float(1)
  ["weekday"]=>
  int(0)
  ["weekday_behavior"]=>
  int(0)
  ["first_last_day_of"]=>
  int(0)
  ["days"]=>
  bool(false)
  ["special_type"]=>
  int(0)
  ["special_amount"]=>
  int(0)
  ["have_weekday_relative"]=>
  int(0)
  ["have_special_relative"]=>
  int(0)
  ["y"]=>
  int(0)
  ["m"]=>
  int(2)
  ["d"]=>
  int(20)
  ["h"]=>
  int(0)
  ["i"]=>
  int(0)
  ["s"]=>
  int(-86400)
  ["invert"]=>
  int(0)
}
```

In this PR, we resolve the issue and add PHP 7.1 compliance by reprogramming the `oat\dtms\DateTime::diff()` method. We also added additional unit tests.