### PR TITLE
chore: enforce PHP ^8.3 dependency for package resolution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "issues": "https://github.com/oat-sa/lib-tao-dtms/issues"
     },
     "require": {
-        "php" : "^7.4 || ~8"
+        "php" : "^8.4"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "issues": "https://github.com/oat-sa/lib-tao-dtms/issues"
     },
     "require": {
-        "php" : "^8.4"
+        "php" : "^8.3"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum PHP requirement to 8.3+. This change means the application now requires PHP 8.3 or newer to run and may affect hosting or deployment environments; please ensure servers and toolchains are updated accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->